### PR TITLE
wkhtmltopdf Dockerfile

### DIFF
--- a/wkhtmltopdf/Dockerfile
+++ b/wkhtmltopdf/Dockerfile
@@ -1,0 +1,27 @@
+FROM cxhjet/flask-py3.6:1.0
+RUN apk add --no-cache \
+            xvfb \
+            # Additionnal dependencies for better rendering
+            ttf-freefont \
+            fontconfig \
+            dbus \
+    && \
+
+    # Install wkhtmltopdf from `testing` repository
+    apk add qt5-qtbase-dev \
+            wkhtmltopdf \
+            --no-cache \
+            --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ \
+            --allow-untrusted \
+    && \
+
+    # Wrapper for xvfb
+    mv /usr/bin/wkhtmltopdf /usr/bin/wkhtmltopdf-origin && \
+    echo $'#!/usr/bin/env sh\n\
+Xvfb :0 -screen 0 1024x768x24 -ac +extension GLX +render -noreset & \n\
+DISPLAY=:0.0 wkhtmltopdf-origin $@ \n\
+killall Xvfb\
+' > /usr/bin/wkhtmltopdf && \
+    chmod +x /usr/bin/wkhtmltopdf
+COPY ./requirements.txt /var/requirements.txt
+RUN pip install -r /var/requirements.txt


### PR DESCRIPTION
FROM cxhjet/flask-py3.6:1.0
RUN apk add --no-cache \
            xvfb \
            # Additionnal dependencies for better rendering
            ttf-freefont \
            fontconfig \
            dbus \
    && \

    # Install wkhtmltopdf from `testing` repository
    apk add qt5-qtbase-dev \
            wkhtmltopdf \
            --no-cache \
            --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ \
            --allow-untrusted \
    && \

    # Wrapper for xvfb
    mv /usr/bin/wkhtmltopdf /usr/bin/wkhtmltopdf-origin && \
    echo $'#!/usr/bin/env sh\n\
Xvfb :0 -screen 0 1024x768x24 -ac +extension GLX +render -noreset & \n\
DISPLAY=:0.0 wkhtmltopdf-origin $@ \n\
killall Xvfb\
' > /usr/bin/wkhtmltopdf && \
    chmod +x /usr/bin/wkhtmltopdf
COPY ./requirements.txt /var/requirements.txt
RUN pip install -r /var/requirements.txt